### PR TITLE
Replaced latest version link under Versions in the readme to correct one

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ You will need the following software installed:
 * [Stacked-Success Versions](https://github.com/Stacked-Success/Softeng310/releases)
 
  **View individual versions**:
-* [Stacked-Success v1.0.3](https://github.com/Stacked-Success/Softeng310/releases/tag/v1.0.4) (Latest)
+* [Stacked-Success v1.0.4](https://github.com/Stacked-Success/Softeng310/releases/tag/v.1.0.4) (Latest)
 * [Stacked-Success v1.0.3](https://github.com/Stacked-Success/Softeng310/releases/tag/v1.0.3)
 * [Stacked-Success v1.0.2](https://github.com/Stacked-Success/Softeng310/releases/tag/v1.0.2)
 * [Stacked-Success v1.0.1](https://github.com/Stacked-Success/Softeng310/releases/tag/v1.0.1)


### PR DESCRIPTION
## Description
Replaced the link in the README under the "Versions" heading for the latest release for v.1.0.4 to the correct link because previously, it would take us to an error 404 page.

closes #104 