### PR TITLE
Ensured skins are persisted between sessions, but reset on a new clone

### DIFF
--- a/src/main/java/com/stackedsuccess/managers/TetriminoImageManager.java
+++ b/src/main/java/com/stackedsuccess/managers/TetriminoImageManager.java
@@ -11,6 +11,7 @@ public class TetriminoImageManager {
     private static TetriminoImageManager instance;
     private static final String DEFAULT_SKIN = "DefaultSkin";
     private static final String PREF_SKIN_KEY = "selectedSkin";
+    private static final String PREF_FIRST_RUN_KEY = "firstRun";
     
     private String imagePath = "file:src/main/resources/images/";
     private static final String IMAGE_EXTENSION = ".png";
@@ -28,6 +29,13 @@ public class TetriminoImageManager {
     private TetriminoImageManager() {
         tetriminoImages = new HashMap<>();
         prefs = Preferences.userNodeForPackage(TetriminoImageManager.class);
+
+        boolean isFirstRun = prefs.getBoolean(PREF_FIRST_RUN_KEY, true);
+        if (isFirstRun) {
+            prefs.putBoolean(PREF_FIRST_RUN_KEY, false);
+            prefs.put(PREF_SKIN_KEY, DEFAULT_SKIN);
+        }
+
         String savedSkin = prefs.get(PREF_SKIN_KEY, DEFAULT_SKIN);
         setSkinTheme(savedSkin);
     }


### PR DESCRIPTION
## Description
This PR implements skin persistence per user, ensuring that skin selections are saved locally for each individual user and reset on a new repository clone.

closes #109 

## Features:
- User-specific Skin Persistence: The selected skin is now saved using the Java Preferences API, ensuring the chosen skin is stored locally for each user.
- Reset on New Clone: If the repository is cloned anew, the skin selection resets to the DefaultSkin for a fresh start, maintaining the default state.
- Session Persistence: Skins selected by users are retained between sessions, but specific to their machine’s preferences, so shared clones won't affect others.